### PR TITLE
Update copyright note to WSO2 LLC

### DIFF
--- a/en/theme/material/partials/footer.html
+++ b/en/theme/material/partials/footer.html
@@ -44,8 +44,8 @@
             {{ config.copyright }}
           </div>
         {% endif %}
-        Copyright &copy; <a href="https://wso2.com/">WSO2</a> Inc. 2017-2021 | Content licensed under
-        <a href="https://creativecommons.org/licenses/by/4.0">CC By 4.0 | </a>
+        Copyright &copy; <a href="https://wso2.com/">WSO2</a> LLC 2017-2022 | Content licensed under
+        <a href="https://creativecommons.org/licenses/by/4.0">CC By 4.0 | </a> </br/>
         Sample code licensed under <a href="http://www.apache.org/licenses/"> Apache 2.0 </a>
       </div>
     </div>


### PR DESCRIPTION
This is to update the footer note as follows:
<img width="1213" alt="Screenshot 2022-07-21 at 14 12 13" src="https://user-images.githubusercontent.com/14251853/180170759-12979ac1-b4ad-433d-aec5-ea83c1aa3b7e.png">

