### PR TITLE
Change token call type to MTLS from private key JWT

### DIFF
--- a/en/docs/get-started/configure-users-and-roles.md
+++ b/en/docs/get-started/configure-users-and-roles.md
@@ -2,7 +2,7 @@ Now you have started the servers, let’s create the users and define their perm
  
 ## Sign in to the Identity Server
  
-1. Sign in to the Management Console of WSO2 Identity Server at [https://localhost:9446/carbon](https://localhost:9446/carbon)
+1. Sign in to the Management Console of WSO2 Identity Server at [https://<IS_HOST>:9446/carbon](https://<IS_HOST>:9446/carbon)
 
 2. Use the default super admin credentials as follows:
     - Username: admin@wso2.com

--- a/en/docs/get-started/tpp-onboarding.md
+++ b/en/docs/get-started/tpp-onboarding.md
@@ -159,7 +159,7 @@ The TPP application requires a Client ID (Consumer Key) to access the subscribed
       curl -X POST \
       https://<IS_HOST>:9446/oauth2/token \
       --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
-      -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
+      -d 'grant_type=client_credentials&scope=accounts&client_id=<CLIENT_ID>'
       ```
 
 7. Upon successful token generation, you can obtain an access token as follows:

--- a/en/docs/get-started/tpp-onboarding.md
+++ b/en/docs/get-started/tpp-onboarding.md
@@ -120,73 +120,41 @@ The TPP application requires a Client ID (Consumer Key) to access the subscribed
 
 4. Note down the **Consumer Key** for your application.
 
-5. Generate the client assertion by signing the following JSON payload using supported algorithms.
+5. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 
-    ??? note "Use the sample certificates for signing and transports layer security testing purposes. Click here to see how it is done..."
-        1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
-           - The client trust stores for the Identity Server and API Manager are located in the following locations:
-               - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
-               - `<IS_HOME>/repository/resources/security/client-truststore.jks`
-        2. Use the following commands to add the certificate to the client trust store:
-           ```shell
-           keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
-           ```
-        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-              - Add `SHA1withRSA` as a supported signature algorithm:
-               ```
-               supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
-               ```
-              - Update the following tag according to the sample:
-               ```
-               [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-               issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OpenBanking Pre-Production Issuing CA, OU=OpenBanking, O=WSO2 (UK) LIMITED, L=COL, ST=WP, C=LK"
-               ```
-        4. Restart the servers.
-        5. Download the following certificates and keys, and use them for testing purposes.
-            - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
-              [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport 
-              layer security testing purposes.
-            - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
-              [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
+   ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
+       1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
+       - The client trust stores for the Identity Server and API Manager are located in the following locations:
+       - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
+       - `<IS_HOME>/repository/resources/security/client-truststore.jks`
+       2. Use the following commands to add the certificate to the client trust store:
+       ```shell
+       keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
+       ```
+       3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
+       - Add `SHA1withRSA` as a supported signature algorithm:
+       ```
+       supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
+       ```
+       - Update the following tag according to the sample:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OpenBanking Pre-Production Issuing CA, OU=OpenBanking, O=WSO2 (UK) LIMITED, L=COL, ST=WP, C=LK"
+       ```
+       4. Restart the servers.
+       5. Download the following certificates and keys, and use them for testing purposes.
+       - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
+       [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
+       layer security testing purposes.
+       - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
+       [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.   
 
-    ``` tab='Format'
-    
-    {
-    "alg": "<The algorithm used for signing.>",
-    "kid": "<The thumbprint of the certificate.>",
-    "typ": "JWT"
-    }
-     
-    {
-    "iss": "<This is the issuer of the token. For example, client ID of your application>",
-    "sub": "<This is the subject identifier of the issuer. For example, client ID of your application>",
-    "exp": <This is the epoch time of the token expiration date/time>,
-    "iat": <This is the epoch time of the token issuance date/time>,
-    "jti": "<This is an incremental unique value>",
-    "aud": "<This is the audience that the ID token is intended for. For example, https://<IS_HOST>:9446/oauth2/token>"
-    }
-     
-    <signature: Use the private signature of the application certificate.>
-    ```
-    
-    ``` tab='Sample'
-    eyJraWQiOiIyTUk5WFNLaTZkZHhDYldnMnJoRE50VWx4SmMiLCJhbGciOiJQUzI1NiJ9.eyJzdWIiOiJZRGNHNGY0OUcxM2tXZlZzbnFkaHo4Z2JhMndhIiwiYXVkIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTQ0Ni9vYXV0aDIvdG9rZW4iLCJpc3MiOiJZRGNHNGY0OUcxM2tXZlZzbnFkaHo4Z2JhMndhIiwiZXhwIjoxNjI4Nzc0ODU1LCJpYXQiOjE2Mjg3NDQ4NTUsImp0aSI6IjE2Mjg3NDQ4NTUxOTQifQ.PkKRSDtkCyXabzLgGwAoy5C3jSORVU8X8sGDVrKpetPnjbCNx2wPlH-PzWUU1n05gdC7lDmoU21nsKLF_nE3iC-9hKEy4YsvJ7PFjNBPMOMUYDhRh9PCkPnec6f042zonb_ZifBq8r1aScUDoZ1L0hq7yjfZubwReFCWbESQ8PauuBuHRl7__kWvglthfgruQ7TTiIWiM60LWYct5TQWSF1IDcYGy03l-9OV5l260JBHPT4heLXzUQTarsh0PoWpv09xYLu8uGCexEt-HtRH8qwJGiFi5PiCA09_KyWVqbrcdjBloCmD5Kiqa1X0AnEbf9kKs0fqvcl7NN5-yVQUjg
-    ```
-    
-    ??? tip "The value of the `aud` claim should contain the same value as the `Identity Provider Entity ID`. Click here to see the Identity Provider Entity ID..."
-        a. Sign in to the Management Console of the Identity Server at `<https://<localhost>t:9446/carbon>`.
-    
-        b. In the **Main** menu, go to **Home > Identity > Identity Providers > Resident**.
-    
-        c. View the value in **Resident Identity Provider > Inbound Authentication Configuration > OAuth2/OpenID Connect Configuration > Identity Provider Entity ID**. By default this value is set to `https://<APIM_HOST>:8243/token` .
-
-6. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
-    ``` curl
-    curl -X POST \
-    https://localhost:9446/oauth2/token \
-    --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
-    -d 'grant_type=client_credentials&scope=accounts%20openid&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion=<CLIENT_ASSERTION_JWT>&redirect_uri=<REDIRECT_URI>&client_id=<CLIENT_ID>'
-    ```
+   ``` curl
+   curl -X POST \
+   https://localhost:9446/oauth2/token \
+   --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+   -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
+   ```
 
 7. Upon successful token generation, you can obtain an access token as follows:
 

--- a/en/docs/get-started/tpp-onboarding.md
+++ b/en/docs/get-started/tpp-onboarding.md
@@ -2,7 +2,7 @@ This page explains how to onboard the TPP applications using the WSO2 API Manage
 
 ### Step 1: Sign up as a TPP
 
-1. Go to the Developer portal at <https://localhost:9443/devportal>.
+1. Go to the Developer portal at <https://<APIM_HOST>:9443/devportal>.
 
 2. Go to the **Applications** tab. ![applications_tab](../assets/img/get-started/quick-start-guide/tpp-onboarding/applications-tab.png)
 
@@ -18,7 +18,7 @@ This page explains how to onboard the TPP applications using the WSO2 API Manage
 
 ### Step 2: Sign in to the Developer Portal as the TPP
 
-1. Now, sign in to the [Developer portal](https://localhost:9443/devportal) as the TPP.
+1. Now, sign in to the [Developer portal](https://<APIM_HOST>:9443/devportal) as the TPP.
 
 2. Enter the username and the password you entered when signing up as a TPP.
 
@@ -151,7 +151,7 @@ The TPP application requires a Client ID (Consumer Key) to access the subscribed
 
    ``` curl
    curl -X POST \
-   https://localhost:9446/oauth2/token \
+   https://<IS_HOST>:9446/oauth2/token \
    --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
    -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
    ```

--- a/en/docs/get-started/tpp-onboarding.md
+++ b/en/docs/get-started/tpp-onboarding.md
@@ -120,41 +120,47 @@ The TPP application requires a Client ID (Consumer Key) to access the subscribed
 
 4. Note down the **Consumer Key** for your application.
 
-5. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
+   5. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 
-   ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
-       1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
-       - The client trust stores for the Identity Server and API Manager are located in the following locations:
-       - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
-       - `<IS_HOME>/repository/resources/security/client-truststore.jks`
-       2. Use the following commands to add the certificate to the client trust store:
-       ```shell
-       keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
-       ```
-       3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-       - Add `SHA1withRSA` as a supported signature algorithm:
-       ```
-       supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
-       ```
-       - Update the following tag according to the sample:
-       ```
-       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OpenBanking Pre-Production Issuing CA, OU=OpenBanking, O=WSO2 (UK) LIMITED, L=COL, ST=WP, C=LK"
-       ```
-       4. Restart the servers.
-       5. Download the following certificates and keys, and use them for testing purposes.
-       - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
-       [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
-       layer security testing purposes.
-       - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
-       [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.   
+      ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
+          1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
+          - The client trust stores for the Identity Server and API Manager are located in the following locations:
+          - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
+          - `<IS_HOME>/repository/resources/security/client-truststore.jks`
+          2. Use the following commands to add the certificate to the client trust store:
+          ```shell
+          keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
+          ```
+          3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
+             - Add the relevant signature algorithm supported by the certificate to the following configuration.
+             - Sample certificate supports `SHA1withRSA` signature algorithm:
+          ```
+          supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
+          ```
+          - Configure the issuer of the certificate as below if the certificate needs to be skipped form revocation validation:
+          ```
+          [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+          issuer_dn = "EMAILADDRESS=<EMAIL_ADDRESS>, CN=<COMMON_NAME>, OU=<ORGANIZATIONAL_UNIT>, O=<ORGANIZATION>, L=<LOCALITY>, ST=<STATE/PROVINCE>, C=<COUNTRY>"
+          ```
+          - Configure as below if the test certificates are used:
+          ```
+          [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+          issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
+          ```
+          4. Restart the servers.
+          5. Download the following certificates and keys, and use them for testing purposes.
+          - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
+          [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
+          layer security testing purposes.
+          - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
+          [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.   
 
-   ``` curl
-   curl -X POST \
-   https://<IS_HOST>:9446/oauth2/token \
-   --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
-   -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
-   ```
+      ``` curl
+      curl -X POST \
+      https://<IS_HOST>:9446/oauth2/token \
+      --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+      -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
+      ```
 
 7. Upon successful token generation, you can obtain an access token as follows:
 

--- a/en/docs/get-started/try-out-flow.md
+++ b/en/docs/get-started/try-out-flow.md
@@ -47,7 +47,7 @@ Once you register the application, generate an application access token.
    curl -X POST \
    https://<IS_HOST>:9446/oauth2/token \
    --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
-   -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
+   -d 'grant_type=client_credentials&scope=accounts&client_id=<CLIENT_ID>'
    ```
 
 2. Upon successful token generation, you can obtain a token as follows:

--- a/en/docs/get-started/try-out-flow.md
+++ b/en/docs/get-started/try-out-flow.md
@@ -8,68 +8,43 @@ Service (AIS) as a sample. For more information, see the [Try out](../try-out/ac
 
 Once you register the application, generate an application access token.
 
-1. Generate the client assertion by signing the following JSON payload using supported algorithms. 
+1. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 
-    ??? note "Use the sample certificates for signing and transports layer security testing purposes. Click here to see how it is done..."
+    ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
         1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
-            - The client trust stores for the Identity Server and API Manager are located in the following locations:
-               - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
-               - `<IS_HOME>/repository/resources/security/client-truststore.jks`
+        - The client trust stores for the Identity Server and API Manager are located in the following locations:
+        - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
+        - `<IS_HOME>/repository/resources/security/client-truststore.jks`
         2. Use the following commands to add the certificate to the client trust store:
-               ```shell
-               keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
-               ```
+        ```shell
+        keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
+        ```
         3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-            - Add `SHA1withRSA` as a supported signature algorithm:
-               ```
-               supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
-               ```
-            - Update the following tag according to the sample:
-               ```
-               [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-               issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OpenBanking Pre-Production Issuing CA, OU=OpenBanking, O=WSO2 (UK) LIMITED, L=COL, ST=WP, C=LK"
-               ```
+        - Add `SHA1withRSA` as a supported signature algorithm:
+        ```
+        supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
+        ```
+        - Update the following tag according to the sample:
+        ```
+        [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+        issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OpenBanking Pre-Production Issuing CA, OU=OpenBanking, O=WSO2 (UK) LIMITED, L=COL, ST=WP, C=LK"
+        ```
         4. Restart the servers.
         5. Download the following certificates and keys, and use them for testing purposes.
-            - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
-              [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
-              layer security testing purposes.
-            - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
-              [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
+        - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
+        [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
+        layer security testing purposes.
+        - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
+        [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
 
-    ``` tab='Format'
-    
-    {
-    "alg": "<The algorithm used for signing.>",
-    "kid": "<The thumbprint of the certificate.>",
-    "typ": "JWT"
-    }
-    {
-    "iss": "<This is the issuer of the token. For example, client ID of your application>",
-    "sub": "<This is the subject identifier of the issuer. For example, client ID of your application>",
-    "exp": <This is the epoch time of the token expiration date/time>,
-    "iat": <This is the epoch time of the token issuance date/time>,
-    "jti": "<This is an incremental unique value>",
-    "aud": "<This is the audience that the ID token is intended for. For example, https://<IS_HOST>:9446/oauth2/token>"
-    }
-   
-    <signature: The client assertion must be signed using the private key of the application certificate.>
+   ``` curl
+   curl -X POST \
+   https://localhost:9446/oauth2/token \
+   --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+   -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
+   ```
 
-    ```
-    
-    ``` tab='Sample'
-    eyJraWQiOiJXX1RjblFWY0hBeTIwcTh6Q01jZEJ5cm9vdHciLCJhbGciOiJQUzI1NiJ9.eyJzdWIiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiYXVkIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTQ0Ni9vYXV0aDIvdG9rZW4iLCJpc3MiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiZXhwIjoxODI3NjY5MzMyLCJpYXQiOjE4Mjc2NTkzMzIsImp0aSI6IjE0MzIyNDM2MzQzNDM1NDQ1In0.qUq9q_Qa5eiVW5C6QzMvB1sX9Ttwz0Db8c2wmRXyrUWDpeoaolUYT_Diu1o33R4U4MME3nBMCdl0wQ1AVnuzjgV6s3TLcyxlphcoGXYVwOLsQBfbLKTzGiz10UORb3WQc9BwxhZVPDWyFXGlqUNwjPbaUslWoal9KMsbnXlBFKQd8GWjhS-kXHn66kAHwH-7DLZ_Z7D01oW2aFon5sWBZfKD_t9NeQJ9gdPs45ermSM45FixlKXkPPXiIq-_w5Hw1Zw_lEW6fVpWCS6IRz5pBtpHO8s_KESjxuPb1dzrV31AZC7BplWeaRRC5UslObbejw35P5v9CQqJR5Uc7_mX0Q
-    ```
-
-2. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
-``` curl
-curl -X POST \
-https://<IS_HOST>:9446/oauth2/token \
---cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
--d 'grant_type=client_credentials&scope=accounts%20openid&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion=<CLIENT_ASSERTION_JWT>&redirect_uri=<REDIRECT_URI>&client_id=<CLIENT_ID>'
-```
-
-3. Upon successful token generation, you can obtain a token as follows:
+2. Upon successful token generation, you can obtain a token as follows:
 ``` json
 {
    "access_token":"eyJ4NXQiOiJOVGRtWmpNNFpEazNOalkwWXpjNU1tWm1PRGd3TVRFM01XWXdOREU1TVdSbFpEZzROemM0WkEiLCJraWQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZ19SUzI1NiIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiJhZG1pbkB3c28yLmNvbUBjYXJib24uc3VwZXIiLCJhdXQiOiJBUFBMSUNBVElPTiIsImF1ZCI6IlBTREdCLU9CLVVua25vd24wMDE1ODAwMDAxSFFRclpBQVgiLCJuYmYiOjE2NDY4OTEyNzIsImF6cCI6IlBTREdCLU9CLVVua25vd24wMDE1ODAwMDAxSFFRclpBQVgiLCJzY29wZSI6ImFjY291bnRzIiwiaXNzIjoiaHR0cHM6XC9cL2xvY2FsaG9zdDo5NDQ2XC9vYXV0aDJcL3Rva2VuIiwiY25mIjp7Ing1dCNTMjU2IjoieWJlcWFJbTUwMElNUHkxOVZrUGZIUlRKTnQ5cXZfUXQ1am1IZHQtYkptYyJ9LCJleHAiOjE2NDY4OTQ4NzIsImlhdCI6MTY0Njg5MTI3MiwianRpIjoiNGY4NDZkMDEtNGYwMS00OGEwLWI5YjItYjk3Yzc0ZmY1MWE4In0.cGQ8h0q9WqPM0VcqNLFz0fnWshPxuqNqJCwqierPjCS84pTK9vYVZqzy66-g-tNylFv9RzMYepOoFCFOcGfUAdtj_PR9GRLnRxKHgiCJMhiVEnZQ1kI0sSICqAB9ezGmtJgZwz2pqfnikCOFz-zTO0UumNDxJ48Qx6U4cr98aG34XLg4EKbvsCbIJuPPM1-sqRgPiQPKQ2EyNzHfRWeNPES5J8UhrIcVZ8pfrBqZ68eMFZxYQ7Bzg9Ch3PDcZyNYczGYFmNJD_pyoccZo5bSC7DDp9r4giQR2P_jL23N4AcKz0eww1FsTQOktBtRGrZ2-RT6zqh5kJ0E20BPYOv8Wg",
@@ -368,65 +343,40 @@ given below:
 
 In this section, you will be generating an access token using the authorization code generated in the section [above](#authorizing-a-consent).
 
-1. Generate the client assertion by signing the following JSON payload using supported algorithms. 
+1. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 
-    ??? note "Use the sample certificates for signing and transports layer security testing purposes. Click here to see how it is done..."
-        1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
-           - The client trust stores for the Identity Server and API Manager are located in the following locations:
-              - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
-              - `<IS_HOME>/repository/resources/security/client-truststore.jks`
-        2. Use the following commands to add the certificate to the client trust store:
-           ```shell
-           keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
-           ```
-        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-            - Add `SHA1withRSA` as a supported signature algorithm:
-              ```
-              supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
-              ```
-            - Update the following tag according to the sample:
-              ```
-              [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-              issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OpenBanking Pre-Production Issuing CA, OU=OpenBanking, O=WSO2 (UK) LIMITED, L=COL, ST=WP, C=LK"
-              ```
-        4. Restart the servers.
-        5. Download the following certificates and keys, and use them for testing purposes.
-            - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
-              [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
-              layer security testing purposes.
-            - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
-              [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
+   ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
+       1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
+       - The client trust stores for the Identity Server and API Manager are located in the following locations:
+       - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
+       - `<IS_HOME>/repository/resources/security/client-truststore.jks`
+       2. Use the following commands to add the certificate to the client trust store:
+       ```shell
+       keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
+       ```
+       3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
+       - Add `SHA1withRSA` as a supported signature algorithm:
+       ```
+       supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
+       ```
+       - Update the following tag according to the sample:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OpenBanking Pre-Production Issuing CA, OU=OpenBanking, O=WSO2 (UK) LIMITED, L=COL, ST=WP, C=LK"
+       ```
+       4. Restart the servers.
+       5. Download the following certificates and keys, and use them for testing purposes.
+       - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
+       [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
+       layer security testing purposes.
+       - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
+       [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
 
-    ``` tab="Format"
-      {
-      "alg": "<The algorithm used for signing.>",
-      "kid": "<The thumbprint of the certificate.>",
-      "typ": "JWT"
-      }
-     
-      {
-      "iss": "<This is the issuer of the token. For example, client ID of your application>",
-      "sub": "<This is the subject identifier of the issuer. For example, client ID of your application>",
-      "exp": <This is the epoch time of the token expiration date/time>,
-      "iat": <This is the epoch time of the token issuance date/time>,
-      "jti": "<This is an incremental unique value>",
-      "aud": "<This is the audience that the ID token is intended for. For example, https://<IS_HOST>:9446/oauth2/token>"
-      }
-   
-      <signature: The client assertion must be signed using the private key of the application certificate.>
-    ```
-
-    ``` tab="Sample"
-    eyJraWQiOiJXX1RjblFWY0hBeTIwcTh6Q01jZEJ5cm9vdHciLCJhbGciOiJQUzI1NiJ9.eyJzdWIiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiYXVkIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTQ0Ni9vYXV0aDIvdG9rZW4iLCJpc3MiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiZXhwIjoxODI3NjY5MzMyLCJpYXQiOjE4Mjc2NTkzMzIsImp0aSI6IjE0MzIyNDM2MzQzNDM1NDQ1In0.qUq9q_Qa5eiVW5C6QzMvB1sX9Ttwz0Db8c2wmRXyrUWDpeoaolUYT_Diu1o33R4U4MME3nBMCdl0wQ1AVnuzjgV6s3TLcyxlphcoGXYVwOLsQBfbLKTzGiz10UORb3WQc9BwxhZVPDWyFXGlqUNwjPbaUslWoal9KMsbnXlBFKQd8GWjhS-kXHn66kAHwH-7DLZ_Z7D01oW2aFon5sWBZfKD_t9NeQJ9gdPs45ermSM45FixlKXkPPXiIq-_w5Hw1Zw_lEW6fVpWCS6IRz5pBtpHO8s_KESjxuPb1dzrV31AZC7BplWeaRRC5UslObbejw35P5v9CQqJR5Uc7_mX0Q
-    ```
-
-2. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
-    
-    ```
+    ``` curl
     curl -X POST \
     https://<IS_HOST>:9446/oauth2/token \
     --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
-    -d 'client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&code=<GENERATED_CODE>&grant_type=authorization_code&redirect_uri=<REDIRECT_URI>&client_assertion=<CLIENT_ASSERTION_JWT>&code_verifier=<CODE_VERIFIER>'
+    -d 'code=<GENERATED_CODE>&grant_type=authorization_code&redirect_uri=<REDIRECT_URI>&code_verifier=<CODE_VERIFIER>&client_id=<CLIENT_ID>'
     ```
 
 3. Upon successful token generation, you can obtain a token as follows:

--- a/en/docs/get-started/try-out-flow.md
+++ b/en/docs/get-started/try-out-flow.md
@@ -39,7 +39,7 @@ Once you register the application, generate an application access token.
 
    ``` curl
    curl -X POST \
-   https://localhost:9446/oauth2/token \
+   https://<IS_HOST>:9446/oauth2/token \
    --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
    -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
    ```

--- a/en/docs/get-started/try-out-flow.md
+++ b/en/docs/get-started/try-out-flow.md
@@ -19,16 +19,22 @@ Once you register the application, generate an application access token.
         ```shell
         keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
         ```
-        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-        - Add `SHA1withRSA` as a supported signature algorithm:
-        ```
-        supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
-        ```
-        - Update the following tag according to the sample:
-        ```
-        [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-        issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OpenBanking Pre-Production Issuing CA, OU=OpenBanking, O=WSO2 (UK) LIMITED, L=COL, ST=WP, C=LK"
-        ```
+       3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
+          - Add the relevant signature algorithm supported by the certificate to the following configuration.
+          - Sample certificate supports `SHA1withRSA` signature algorithm:
+       ```
+       supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
+       ```
+       - Configure the issuer of the certificate as below if the certificate needs to be skipped form revocation validation:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=<EMAIL_ADDRESS>, CN=<COMMON_NAME>, OU=<ORGANIZATIONAL_UNIT>, O=<ORGANIZATION>, L=<LOCALITY>, ST=<STATE/PROVINCE>, C=<COUNTRY>"
+       ```
+       - Configure as below if the test certificates are used:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
+       ```
         4. Restart the servers.
         5. Download the following certificates and keys, and use them for testing purposes.
         - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
@@ -355,14 +361,20 @@ In this section, you will be generating an access token using the authorization 
        keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
        ```
        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-       - Add `SHA1withRSA` as a supported signature algorithm:
+          - Add the relevant signature algorithm supported by the certificate to the following configuration.
+          - Sample certificate supports `SHA1withRSA` signature algorithm:
        ```
        supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
        ```
-       - Update the following tag according to the sample:
+       - Configure the issuer of the certificate as below if the certificate needs to be skipped form revocation validation:
        ```
        [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OpenBanking Pre-Production Issuing CA, OU=OpenBanking, O=WSO2 (UK) LIMITED, L=COL, ST=WP, C=LK"
+       issuer_dn = "EMAILADDRESS=<EMAIL_ADDRESS>, CN=<COMMON_NAME>, OU=<ORGANIZATIONAL_UNIT>, O=<ORGANIZATION>, L=<LOCALITY>, ST=<STATE/PROVINCE>, C=<COUNTRY>"
+       ```
+       - Configure as below if the test certificates are used:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
        ```
        4. Restart the servers.
        5. Download the following certificates and keys, and use them for testing purposes.

--- a/en/docs/install-and-setup/configuring-identity-server-for-ob.md
+++ b/en/docs/install-and-setup/configuring-identity-server-for-ob.md
@@ -204,7 +204,7 @@ the consent page.
 
      ``` toml
      [open_banking_berlin.consent.sca]
-     oauth_metadata_endpoint = "https://localhost:8243/.well-known/openid-configuration"
+     oauth_metadata_endpoint = "https://<APIM_HOST>:8243/.well-known/openid-configuration"
      ```
 
 18. Configure the base URL for payment submission as follows:

--- a/en/docs/install-and-setup/configuring-identity-server-for-ob.md
+++ b/en/docs/install-and-setup/configuring-identity-server-for-ob.md
@@ -204,7 +204,7 @@ the consent page.
 
      ``` toml
      [open_banking_berlin.consent.sca]
-     oauth_metadata_endpoint = "https://<APIM_HOST>:8243/.well-known/openid-configuration"
+     oauth_metadata_endpoint = "https://localhost:8243/.well-known/openid-configuration"
      ```
 
 18. Configure the base URL for payment submission as follows:

--- a/en/docs/install-and-setup/configuring-users-and-roles.md
+++ b/en/docs/install-and-setup/configuring-users-and-roles.md
@@ -2,7 +2,7 @@ Now you have started the servers, let’s create the users and define their perm
 
 ## Sign in to the Identity Server
 
-1. Sign in to the Management Console of WSO2 Identity Server at [https://localhost:9446/carbon](https://localhost:9446/carbon)
+1. Sign in to the Management Console of WSO2 Identity Server at [https://<IS_HOST>:9446/carbon](https://<IS_HOST>:9446/carbon)
 
 2. Use the default super admin credentials as follows:
     - Username: admin@wso2.com

--- a/en/docs/learn/consent-manager.md
+++ b/en/docs/learn/consent-manager.md
@@ -191,7 +191,7 @@ Follow [Configuring users and roles](../install-and-setup/configuring-users-and-
         ``` javascript
         window.env = {
             // This option can be retrieved in "src/index.js" with "window.env.API_URL".
-            SERVER_URL: 'https://localhost:9446',
+            SERVER_URL: 'https://<IS_HOST>:9446',
             TENANT_DOMAIN: 'carbon.super',
             NUMBER_OF_CONSENTS: 25,
             VERSION: '3.0.0'
@@ -212,11 +212,11 @@ Follow [Configuring users and roles](../install-and-setup/configuring-users-and-
     ``` xml
     <context-param>
     	<param-name>identityServerBaseUrl</param-name>
-    	<param-value>https://localhost:9446</param-value>
+    	<param-value>https://<IS_HOST>:9446</param-value>
     </context-param>
     <context-param>
     	<param-name>apiManagerServerUrl</param-name>
-    	<param-value>https://localhost:8243</param-value>
+    	<param-value>https://<APIM_HOST>:8243</param-value>
     </context-param>
     <context-param>
     	<param-name>scpClientKey</param-name>

--- a/en/docs/learn/integration-with-bank.md
+++ b/en/docs/learn/integration-with-bank.md
@@ -332,10 +332,10 @@ CoF must be updated individually.
 - Replace the following in the sequence file with the core banking system’s API endpoints for production/sandbox environments:
     - For Accounts (card-accounts) and Payments:
         1. Open the `<APIM_TOOLKIT_HOME>/repository/resources/apis/berlin.group.org/PSD2API_1.3.6/dynamic-endpoint-insequence-1.3.6` file.
-        2. Replace the `https://localhost:9443/api/openbanking/berlin/backend/services/accounts` URL.
+        2. Replace the `https://<APIM_HOST>:9443/api/openbanking/berlin/backend/services/accounts` URL.
     - For CoF submission request:
         1. Open the `<APIM_TOOLKIT_HOME>/repository/resources/apis/berlin.group.org/ConfirmationOfFunds/cof-consents-dynamic-endpoint-sequence-1.3.6` file.
-        2. Replace the `https://localhost:9443/api/openbanking/berlin/backend/services/funds-confirmations` URL.
+        2. Replace the `https://<APIM_HOST>:9443/api/openbanking/berlin/backend/services/funds-confirmations` URL.
 
 
 ## Accounts Retrieval Endpoints

--- a/en/docs/learn/token-authentication.md
+++ b/en/docs/learn/token-authentication.md
@@ -77,7 +77,8 @@ According to OAuth 2.0, the authorization server and the client need to establis
 meets the security requirements of the authorization server. The client has the option of choosing the authentication 
 method. The OpenID specification mentions a set of client authentication methods to authenticate the clients to the 
 authorization server when using the token endpoint. Regulatory applications can use either `private_key_jwt` 
-or `tls_client_auth` as the authentication method.
+or `tls_client_auth` as the authentication method. The NextGenPSD2 implementation guidelines specify `Oauth 2.0 Mutual 
+TLS Client Authentication and Certificate Bound Access Tokens` as the client authentication mechanism.
 
 
 

--- a/en/docs/try-out/account-information-service-flow.md
+++ b/en/docs/try-out/account-information-service-flow.md
@@ -39,7 +39,7 @@ Once you register the application, generate an application access token.
 
 ``` curl
    curl -X POST \
-   https://localhost:9446/oauth2/token \
+   https://<IS_HOST>:9446/oauth2/token \
    --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
    -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
    ```

--- a/en/docs/try-out/account-information-service-flow.md
+++ b/en/docs/try-out/account-information-service-flow.md
@@ -20,11 +20,17 @@ Once you register the application, generate an application access token.
        keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
        ```
        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-       - Add `SHA1withRSA` as a supported signature algorithm:
+       - Add the relevant signature algorithm supported by the certificate to the following configuration.
+       - Sample certificate supports `SHA1withRSA` signature algorithm:
        ```
        supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
        ```
-       - Update the following tag according to the sample:
+       - Configure the issuer of the certificate as below if the certificate needs to be skipped form revocation validation:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=<EMAIL_ADDRESS>, CN=<COMMON_NAME>, OU=<ORGANIZATIONAL_UNIT>, O=<ORGANIZATION>, L=<LOCALITY>, ST=<STATE/PROVINCE>, C=<COUNTRY>"
+       ```
+       - Configure as below if the test certificates are used:
        ```
        [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
        issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
@@ -721,11 +727,17 @@ In this section, you will be generating an access token using the authorization 
        keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
        ```
        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-       - Add `SHA1withRSA` as a supported signature algorithm:
+          - Add the relevant signature algorithm supported by the certificate to the following configuration.
+          - Sample certificate supports `SHA1withRSA` signature algorithm:
        ```
        supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
        ```
-       - Update the following tag according to the sample:
+       - Configure the issuer of the certificate as below if the certificate needs to be skipped form revocation validation:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=<EMAIL_ADDRESS>, CN=<COMMON_NAME>, OU=<ORGANIZATIONAL_UNIT>, O=<ORGANIZATION>, L=<LOCALITY>, ST=<STATE/PROVINCE>, C=<COUNTRY>"
+       ```
+       - Configure as below if the test certificates are used:
        ```
        [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
        issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"

--- a/en/docs/try-out/account-information-service-flow.md
+++ b/en/docs/try-out/account-information-service-flow.md
@@ -47,7 +47,7 @@ Once you register the application, generate an application access token.
    curl -X POST \
    https://<IS_HOST>:9446/oauth2/token \
    --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
-   -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
+   -d 'grant_type=client_credentials&scope=accounts&client_id=<CLIENT_ID>'
    ```
 
 3. Upon successful token generation, you can obtain a token as follows:

--- a/en/docs/try-out/account-information-service-flow.md
+++ b/en/docs/try-out/account-information-service-flow.md
@@ -8,66 +8,41 @@ Service (AIS).
 
 Once you register the application, generate an application access token.
 
-1. Generate the client assertion by signing the following JSON payload using supported algorithms. 
+1. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 
-    ??? note "Use the sample certificates for signing and transport layer security testing purposes. Click here to see how it is done..."
-        1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
-            - The client trust stores for the Identity Server and API Manager are located in the following locations:
-                   - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
-                   - `<IS_HOME>/repository/resources/security/client-truststore.jks`
-        2. Use the following commands to add the certificate to the client trust store:
-               ```shell
-               keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
-               ```
-        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-            - Add `SHA1withRSA` as a supported signature algorithm:
-               ```
-               supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
-               ```
-            - Update the following tag according to the sample:
-               ```
-               [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-               issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
-               ```
-        4. Restart the servers.
-        5. Download the following certificates and keys, and use them for testing purposes.
-            - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
-              [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
-              layer security testing purposes.
-            - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
-              [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
+   ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
+       1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
+       - The client trust stores for the Identity Server and API Manager are located in the following locations:
+       - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
+       - `<IS_HOME>/repository/resources/security/client-truststore.jks`
+       2. Use the following commands to add the certificate to the client trust store:
+       ```shell
+       keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
+       ```
+       3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
+       - Add `SHA1withRSA` as a supported signature algorithm:
+       ```
+       supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
+       ```
+       - Update the following tag according to the sample:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
+       ```
+       4. Restart the servers.
+       5. Download the following certificates and keys, and use them for testing purposes.
+       - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
+       [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
+       layer security testing purposes.
+       - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
+       [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
 
-    ``` tab='Format'
-    
-    {
-    "alg": "<The algorithm used for signing.>",
-    "kid": "<The thumbprint of the certificate.>",
-    "typ": "JWT"
-    }
-    {
-    "iss": "<This is the issuer of the token. For example, client ID of your application>",
-    "sub": "<This is the subject identifier of the issuer. For example, client ID of your application>",
-    "exp": <This is the epoch time of the token expiration date/time>,
-    "iat": <This is the epoch time of the token issuance date/time>,
-    "jti": "<This is an incremental unique value>",
-    "aud": "<This is the audience that the ID token is intended for. For example, https://<IS_HOST>:9446/oauth2/token>"
-    }
-   
-    <signature: The client assertion must be signed using the private key of the application certificate.>
-
-    ```
-    
-    ``` tab='Sample'
-    eyJraWQiOiJXX1RjblFWY0hBeTIwcTh6Q01jZEJ5cm9vdHciLCJhbGciOiJQUzI1NiJ9.eyJzdWIiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiYXVkIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTQ0Ni9vYXV0aDIvdG9rZW4iLCJpc3MiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiZXhwIjoxODI3NjY5MzMyLCJpYXQiOjE4Mjc2NTkzMzIsImp0aSI6IjE0MzIyNDM2MzQzNDM1NDQ1In0.qUq9q_Qa5eiVW5C6QzMvB1sX9Ttwz0Db8c2wmRXyrUWDpeoaolUYT_Diu1o33R4U4MME3nBMCdl0wQ1AVnuzjgV6s3TLcyxlphcoGXYVwOLsQBfbLKTzGiz10UORb3WQc9BwxhZVPDWyFXGlqUNwjPbaUslWoal9KMsbnXlBFKQd8GWjhS-kXHn66kAHwH-7DLZ_Z7D01oW2aFon5sWBZfKD_t9NeQJ9gdPs45ermSM45FixlKXkPPXiIq-_w5Hw1Zw_lEW6fVpWCS6IRz5pBtpHO8s_KESjxuPb1dzrV31AZC7BplWeaRRC5UslObbejw35P5v9CQqJR5Uc7_mX0Q
-    ```
-
-2. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 ``` curl
-curl -X POST \
-https://<IS_HOST>:9446/oauth2/token \
---cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
--d 'grant_type=client_credentials&scope=accounts%20openid&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion=<CLIENT_ASSERTION_JWT>&redirect_uri=<REDIRECT_URI>&client_id=<CLIENT_ID>'
-```
+   curl -X POST \
+   https://localhost:9446/oauth2/token \
+   --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+   -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
+   ```
 
 3. Upon successful token generation, you can obtain a token as follows:
 ``` json
@@ -734,65 +709,40 @@ given below:
 
 In this section, you will be generating an access token using the authorization code generated in the section [above](#authorizing-a-consent).
 
-1. Generate the client assertion by signing the following JSON payload using supported algorithms. 
+1. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 
-    ??? note "Use the sample certificates for signing and transport layer security testing purposes. Click here to see how it is done..."
-        1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
-            - The client trust stores for the Identity Server and API Manager are located in the following locations:
-                  - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
-                  - `<IS_HOME>/repository/resources/security/client-truststore.jks`
-        2. Use the following commands to add the certificate to the client trust store:
-           ```shell
-           keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
-           ```
-        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-            - Add `SHA1withRSA` as a supported signature algorithm:
-              ```
-              supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
-              ```
-            - Update the following tag according to the sample:
-              ```
-              [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-              issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
-              ```
-        4. Restart the servers.
-        5. Download the following certificates and keys, and use them for testing purposes.
-            - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
-              [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
-              layer security testing purposes.
-            - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
-              [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
+   ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
+       1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
+       - The client trust stores for the Identity Server and API Manager are located in the following locations:
+       - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
+       - `<IS_HOME>/repository/resources/security/client-truststore.jks`
+       2. Use the following commands to add the certificate to the client trust store:
+       ```shell
+       keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
+       ```
+       3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
+       - Add `SHA1withRSA` as a supported signature algorithm:
+       ```
+       supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
+       ```
+       - Update the following tag according to the sample:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
+       ```
+       4. Restart the servers.
+       5. Download the following certificates and keys, and use them for testing purposes.
+       - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
+       [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
+       layer security testing purposes.
+       - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
+       [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
 
-    ``` tab="Format"
-      {
-      "alg": "<The algorithm used for signing.>",
-      "kid": "<The thumbprint of the certificate.>",
-      "typ": "JWT"
-      }
-     
-      {
-      "iss": "<This is the issuer of the token. For example, client ID of your application>",
-      "sub": "<This is the subject identifier of the issuer. For example, client ID of your application>",
-      "exp": <This is the epoch time of the token expiration date/time>,
-      "iat": <This is the epoch time of the token issuance date/time>,
-      "jti": "<This is an incremental unique value>",
-      "aud": "<This is the audience that the ID token is intended for. For example, https://<IS_HOST>:9446/oauth2/token>"
-      }
-   
-      <signature: The client assertion must be signed using the private key of the application certificate.>
-    ```
-
-    ``` tab="Sample"
-    eyJraWQiOiJXX1RjblFWY0hBeTIwcTh6Q01jZEJ5cm9vdHciLCJhbGciOiJQUzI1NiJ9.eyJzdWIiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiYXVkIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTQ0Ni9vYXV0aDIvdG9rZW4iLCJpc3MiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiZXhwIjoxODI3NjY5MzMyLCJpYXQiOjE4Mjc2NTkzMzIsImp0aSI6IjE0MzIyNDM2MzQzNDM1NDQ1In0.qUq9q_Qa5eiVW5C6QzMvB1sX9Ttwz0Db8c2wmRXyrUWDpeoaolUYT_Diu1o33R4U4MME3nBMCdl0wQ1AVnuzjgV6s3TLcyxlphcoGXYVwOLsQBfbLKTzGiz10UORb3WQc9BwxhZVPDWyFXGlqUNwjPbaUslWoal9KMsbnXlBFKQd8GWjhS-kXHn66kAHwH-7DLZ_Z7D01oW2aFon5sWBZfKD_t9NeQJ9gdPs45ermSM45FixlKXkPPXiIq-_w5Hw1Zw_lEW6fVpWCS6IRz5pBtpHO8s_KESjxuPb1dzrV31AZC7BplWeaRRC5UslObbejw35P5v9CQqJR5Uc7_mX0Q
-    ```
-
-2. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
-    
-    ```
+    ``` curl
     curl -X POST \
     https://<IS_HOST>:9446/oauth2/token \
     --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
-    -d 'client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&code=<GENERATED_CODE>&grant_type=authorization_code&redirect_uri=<REDIRECT_URI>&client_assertion=<CLIENT_ASSERTION_JWT>&code_verifier=<CODE_VERIFIER>'
+    -d 'code=<GENERATED_CODE>&grant_type=authorization_code&redirect_uri=<REDIRECT_URI>&code_verifier=<CODE_VERIFIER>&client_id=<CLIENT_ID>'
     ```
 
 3. Upon successful token generation, you can obtain a token as follows:

--- a/en/docs/try-out/confirmation-of-funds-flow.md
+++ b/en/docs/try-out/confirmation-of-funds-flow.md
@@ -111,7 +111,7 @@ Once you register the application, generate an application access token.
 
 ``` curl
 curl -X POST \
-https://localhost:9446/oauth2/token \
+https://<IS_HOST>:9446/oauth2/token \
 --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
 -d 'grant_type=client_credentials&scope=fundsconfirmations%20openid&client_id=<CLIENT_ID>'
 ```

--- a/en/docs/try-out/confirmation-of-funds-flow.md
+++ b/en/docs/try-out/confirmation-of-funds-flow.md
@@ -80,65 +80,40 @@ Payment Instrument Issuer Service (PIIS).
 
 Once you register the application, generate an application access token.
 
-1. Generate the client assertion by signing the following JSON payload using supported algorithms.
+1. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 
-    ??? note "Use the sample certificates for signing and transport layer security testing purposes. Click here to see how it is done..."
-        1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
-            - The client trust stores for the Identity Server and API Manager are located in the following locations:
-                   - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
-                   - `<IS_HOME>/repository/resources/security/client-truststore.jks`
-        2. Use the following commands to add the certificate to the client trust store:
-           ```shell
-           keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
-           ```
-        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-            - Add `SHA1withRSA` as a supported signature algorithm:
-              ```
-              supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
-              ```
-            - Update the following tag according to the sample:
-              ```
-              [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-              issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
-              ```
-        4. Restart the servers.
-        5. Download the following certificates and keys, and use them for testing purposes.
-            - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
-              [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
-              layer security testing purposes.
-            - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
-              [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
+   ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
+       1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
+       - The client trust stores for the Identity Server and API Manager are located in the following locations:
+       - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
+       - `<IS_HOME>/repository/resources/security/client-truststore.jks`
+       2. Use the following commands to add the certificate to the client trust store:
+       ```shell
+       keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
+       ```
+       3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
+       - Add `SHA1withRSA` as a supported signature algorithm:
+       ```
+       supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
+       ```
+       - Update the following tag according to the sample:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
+       ```
+       4. Restart the servers.
+       5. Download the following certificates and keys, and use them for testing purposes.
+       - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
+       [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
+       layer security testing purposes.
+       - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
+       [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
 
-    ``` tab='Format'
-    
-    {
-    "alg": "<The algorithm used for signing.>",
-    "kid": "<The thumbprint of the certificate.>",
-    "typ": "JWT"
-    }
-    {
-    "iss": "<This is the issuer of the token. For example, client ID of your application>",
-    "sub": "<This is the subject identifier of the issuer. For example, client ID of your application>",
-    "exp": <This is the epoch time of the token expiration date/time>,
-    "iat": <This is the epoch time of the token issuance date/time>,
-    "jti": "<This is an incremental unique value>",
-    "aud": "<This is the audience that the ID token is intended for. For example, https://<IS_HOST>:9446/oauth2/token>"
-    }
-   
-    <signature: The client assertion must be signed using the private key of the application certificate.>
-
-    ```
-
-    ``` tab='Sample'
-    eyJraWQiOiJXX1RjblFWY0hBeTIwcTh6Q01jZEJ5cm9vdHciLCJhbGciOiJQUzI1NiJ9.eyJzdWIiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiYXVkIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTQ0Ni9vYXV0aDIvdG9rZW4iLCJpc3MiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiZXhwIjoxODI3NjY5MzMyLCJpYXQiOjE4Mjc2NTkzMzIsImp0aSI6IjE0MzIyNDM2MzQzNDM1NDQ1In0.qUq9q_Qa5eiVW5C6QzMvB1sX9Ttwz0Db8c2wmRXyrUWDpeoaolUYT_Diu1o33R4U4MME3nBMCdl0wQ1AVnuzjgV6s3TLcyxlphcoGXYVwOLsQBfbLKTzGiz10UORb3WQc9BwxhZVPDWyFXGlqUNwjPbaUslWoal9KMsbnXlBFKQd8GWjhS-kXHn66kAHwH-7DLZ_Z7D01oW2aFon5sWBZfKD_t9NeQJ9gdPs45ermSM45FixlKXkPPXiIq-_w5Hw1Zw_lEW6fVpWCS6IRz5pBtpHO8s_KESjxuPb1dzrV31AZC7BplWeaRRC5UslObbejw35P5v9CQqJR5Uc7_mX0Q
-    ```
-
-2. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 ``` curl
 curl -X POST \
-https://<IS_HOST>:9446/oauth2/token \
+https://localhost:9446/oauth2/token \
 --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
--d 'grant_type=client_credentials&scope=fundsconfirmations%20openid&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion=<CLIENT_ASSERTION_JWT>&redirect_uri=<REDIRECT_URI>&client_id=<CLIENT_ID>''
+-d 'grant_type=client_credentials&scope=fundsconfirmations%20openid&client_id=<CLIENT_ID>'
 ```
 
 3. Upon successful token generation, you can obtain a token as follows:
@@ -531,65 +506,40 @@ number of PSUs in a multi-level authorisation context.
 
 In this section, you will be generating an access token using the authorization code generated in the section [above](#authorizing-a-consent).
 
-1. Generate the client assertion by signing the following JSON payload using supported algorithms.
+1. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 
-    ??? note "Use the sample certificates for signing and transport layer security testing purposes. Click here to see how it is done..."
-        1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
-            - The client trust stores for the Identity Server and API Manager are located in the following locations:
-                   - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
-                   - `<IS_HOME>/repository/resources/security/client-truststore.jks`
-        2. Use the following commands to add the certificate to the client trust store:
-            ```shell
-            keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
-            ```
-        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-            - Add `SHA1withRSA` as a supported signature algorithm:
-              ```
-              supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
-              ```
-            - Update the following tag according to the sample:
-             ```
-             [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-             issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
-             ```
-        4. Restart the servers.
-        5. Download the following certificates and keys, and use them for testing purposes.
-             - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
-               [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
-               layer security testing purposes.
-             - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
-               [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
+   ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
+       1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
+       - The client trust stores for the Identity Server and API Manager are located in the following locations:
+       - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
+       - `<IS_HOME>/repository/resources/security/client-truststore.jks`
+       2. Use the following commands to add the certificate to the client trust store:
+       ```shell
+       keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
+       ```
+       3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
+       - Add `SHA1withRSA` as a supported signature algorithm:
+       ```
+       supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
+       ```
+       - Update the following tag according to the sample:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
+       ```
+       4. Restart the servers.
+       5. Download the following certificates and keys, and use them for testing purposes.
+       - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
+       [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
+       layer security testing purposes.
+       - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
+       [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
 
-    ``` tab="Format"
-      {
-      "alg": "<The algorithm used for signing.>",
-      "kid": "<The thumbprint of the certificate.>",
-      "typ": "JWT"
-      }
-     
-      {
-      "iss": "<This is the issuer of the token. For example, client ID of your application>",
-      "sub": "<This is the subject identifier of the issuer. For example, client ID of your application>",
-      "exp": <This is the epoch time of the token expiration date/time>,
-      "iat": <This is the epoch time of the token issuance date/time>,
-      "jti": "<This is an incremental unique value>",
-      "aud": "<This is the audience that the ID token is intended for. For example, https://<IS_HOST>:9446/oauth2/token>"
-      }
-   
-      <signature: The client assertion must be signed using the private key of the application certificate.>
-    ```
-
-    ``` tab="Sample"
-    eyJraWQiOiJXX1RjblFWY0hBeTIwcTh6Q01jZEJ5cm9vdHciLCJhbGciOiJQUzI1NiJ9.eyJzdWIiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiYXVkIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTQ0Ni9vYXV0aDIvdG9rZW4iLCJpc3MiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiZXhwIjoxODI3NjY5MzMyLCJpYXQiOjE4Mjc2NTkzMzIsImp0aSI6IjE0MzIyNDM2MzQzNDM1NDQ1In0.qUq9q_Qa5eiVW5C6QzMvB1sX9Ttwz0Db8c2wmRXyrUWDpeoaolUYT_Diu1o33R4U4MME3nBMCdl0wQ1AVnuzjgV6s3TLcyxlphcoGXYVwOLsQBfbLKTzGiz10UORb3WQc9BwxhZVPDWyFXGlqUNwjPbaUslWoal9KMsbnXlBFKQd8GWjhS-kXHn66kAHwH-7DLZ_Z7D01oW2aFon5sWBZfKD_t9NeQJ9gdPs45ermSM45FixlKXkPPXiIq-_w5Hw1Zw_lEW6fVpWCS6IRz5pBtpHO8s_KESjxuPb1dzrV31AZC7BplWeaRRC5UslObbejw35P5v9CQqJR5Uc7_mX0Q
-    ```
-
-2. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
-
-    ```
+    ``` curl
     curl -X POST \
     https://<IS_HOST>:9446/oauth2/token \
-    --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \ 
-    -d 'client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&code=<GENERATED_CODE>&grant_type=authorization_code&redirect_uri=<REDIRECT_URI>&client_assertion=<CLIENT_ASSERTION_JWT>&code_verifier=<CODE_VERIFIER>'
+    --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+    -d 'code=<GENERATED_CODE>&grant_type=authorization_code&redirect_uri=<REDIRECT_URI>&code_verifier=<CODE_VERIFIER>&client_id=<CLIENT_ID>'
     ```
 
 3. Upon successful token generation, you can obtain a token as follows:

--- a/en/docs/try-out/confirmation-of-funds-flow.md
+++ b/en/docs/try-out/confirmation-of-funds-flow.md
@@ -119,7 +119,7 @@ Once you register the application, generate an application access token.
 curl -X POST \
 https://<IS_HOST>:9446/oauth2/token \
 --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
--d 'grant_type=client_credentials&scope=fundsconfirmations%20openid&client_id=<CLIENT_ID>'
+-d 'grant_type=client_credentials&scope=fundsconfirmations&client_id=<CLIENT_ID>'
 ```
 
 3. Upon successful token generation, you can obtain a token as follows:

--- a/en/docs/try-out/confirmation-of-funds-flow.md
+++ b/en/docs/try-out/confirmation-of-funds-flow.md
@@ -92,11 +92,17 @@ Once you register the application, generate an application access token.
        keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
        ```
        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-       - Add `SHA1withRSA` as a supported signature algorithm:
+          - Add the relevant signature algorithm supported by the certificate to the following configuration.
+          - Sample certificate supports `SHA1withRSA` signature algorithm:
        ```
        supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
        ```
-       - Update the following tag according to the sample:
+       - Configure the issuer of the certificate as below if the certificate needs to be skipped form revocation validation:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=<EMAIL_ADDRESS>, CN=<COMMON_NAME>, OU=<ORGANIZATIONAL_UNIT>, O=<ORGANIZATION>, L=<LOCALITY>, ST=<STATE/PROVINCE>, C=<COUNTRY>"
+       ```
+       - Configure as below if the test certificates are used:
        ```
        [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
        issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
@@ -518,11 +524,17 @@ In this section, you will be generating an access token using the authorization 
        keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
        ```
        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-       - Add `SHA1withRSA` as a supported signature algorithm:
+          - Add the relevant signature algorithm supported by the certificate to the following configuration.
+          - Sample certificate supports `SHA1withRSA` signature algorithm:
        ```
        supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
        ```
-       - Update the following tag according to the sample:
+       - Configure the issuer of the certificate as below if the certificate needs to be skipped form revocation validation:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=<EMAIL_ADDRESS>, CN=<COMMON_NAME>, OU=<ORGANIZATIONAL_UNIT>, O=<ORGANIZATION>, L=<LOCALITY>, ST=<STATE/PROVINCE>, C=<COUNTRY>"
+       ```
+       - Configure as below if the test certificates are used:
        ```
        [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
        issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"

--- a/en/docs/try-out/consent-manager.md
+++ b/en/docs/try-out/consent-manager.md
@@ -189,7 +189,7 @@ Follow [Configuring users and roles](../install-and-setup/configuring-users-and-
         ``` javascript
         window.env = {
             // This option can be retrieved in "src/index.js" with "window.env.API_URL".
-            SERVER_URL: 'https://localhost:9446',
+            SERVER_URL: 'https://<IS_HOST>:9446',
             TENANT_DOMAIN: 'carbon.super',
             NUMBER_OF_CONSENTS: 25,
             VERSION: '3.0.0'
@@ -210,11 +210,11 @@ Follow [Configuring users and roles](../install-and-setup/configuring-users-and-
     ``` xml
     <context-param>
     	<param-name>identityServerBaseUrl</param-name>
-    	<param-value>https://localhost:9446</param-value>
+    	<param-value>https://<IS_HOST>:9446</param-value>
     </context-param>
     <context-param>
     	<param-name>apiManagerServerUrl</param-name>
-    	<param-value>https://localhost:8243</param-value>
+    	<param-value>https://<APIM_HOST>:8243</param-value>
     </context-param>
     <context-param>
     	<param-name>scpClientKey</param-name>

--- a/en/docs/try-out/payment-initiation-service-flow.md
+++ b/en/docs/try-out/payment-initiation-service-flow.md
@@ -46,7 +46,7 @@ Once you register the application, generate an application access token.
    curl -X POST \
    https://<IS_HOST>:9446/oauth2/token \
    --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
-   -d 'grant_type=client_credentials&scope=payments%20openid&client_id=<CLIENT_ID>'
+   -d 'grant_type=client_credentials&scope=payments&client_id=<CLIENT_ID>'
    ```
 
 2. Upon successful token generation, you can obtain a token as follows:

--- a/en/docs/try-out/payment-initiation-service-flow.md
+++ b/en/docs/try-out/payment-initiation-service-flow.md
@@ -19,11 +19,17 @@ Once you register the application, generate an application access token.
        keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
        ```
        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-       - Add `SHA1withRSA` as a supported signature algorithm:
+          - Add the relevant signature algorithm supported by the certificate to the following configuration.
+          - Sample certificate supports `SHA1withRSA` signature algorithm:
        ```
        supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
        ```
-       - Update the following tag according to the sample:
+       - Configure the issuer of the certificate as below if the certificate needs to be skipped form revocation validation:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=<EMAIL_ADDRESS>, CN=<COMMON_NAME>, OU=<ORGANIZATIONAL_UNIT>, O=<ORGANIZATION>, L=<LOCALITY>, ST=<STATE/PROVINCE>, C=<COUNTRY>"
+       ```
+       - Configure as below if the test certificates are used:
        ```
        [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
        issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
@@ -527,16 +533,22 @@ In this section, you will be generating an access token using the authorization 
            ```shell
            keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
            ```
-        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-            - Add `SHA1withRSA` as a supported signature algorithm:
-              ```
-              supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
-              ```
-            - Update the following tag according to the sample:
-              ```
-              [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-              issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
-              ```
+       3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
+          - Add the relevant signature algorithm supported by the certificate to the following configuration.
+          - Sample certificate supports `SHA1withRSA` signature algorithm:
+       ```
+       supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
+       ```
+       - Configure the issuer of the certificate as below if the certificate needs to be skipped form revocation validation:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=<EMAIL_ADDRESS>, CN=<COMMON_NAME>, OU=<ORGANIZATIONAL_UNIT>, O=<ORGANIZATION>, L=<LOCALITY>, ST=<STATE/PROVINCE>, C=<COUNTRY>"
+       ```
+       - Configure as below if the test certificates are used:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
+       ```
         4. Restart the servers.
         5. Download the following certificates and keys, and use them for testing purposes.
             - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and

--- a/en/docs/try-out/payment-initiation-service-flow.md
+++ b/en/docs/try-out/payment-initiation-service-flow.md
@@ -7,68 +7,43 @@ This page provides instructions to use the NextGenPSD2XS2AFramework API to provi
 
 Once you register the application, generate an application access token.
 
-1. Generate the client assertion by signing the following JSON payload using supported algorithms. 
+1. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 
-    ??? note "Use the sample certificates for signing and transport layer security testing purposes. Click here to see how it is done..."
-        1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
-            - The client trust stores for the Identity Server and API Manager are located in the following locations:
-                   - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
-                   - `<IS_HOME>/repository/resources/security/client-truststore.jks`
-        2. Use the following commands to add the certificate to the client trust store:
-               ```shell
-               keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
-               ```
-        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-            - Add `SHA1withRSA` as a supported signature algorithm:
-               ```
-               supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
-               ```
-            - Update the following tag according to the sample:
-               ```
-               [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-               issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
-               ```
-        4. Restart the servers.
-        5. Download the following certificates and keys, and use them for testing purposes.
-            - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
-              [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
-              layer security testing purposes.
-            - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
-              [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
+   ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
+       1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
+       - The client trust stores for the Identity Server and API Manager are located in the following locations:
+       - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
+       - `<IS_HOME>/repository/resources/security/client-truststore.jks`
+       2. Use the following commands to add the certificate to the client trust store:
+       ```shell
+       keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
+       ```
+       3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
+       - Add `SHA1withRSA` as a supported signature algorithm:
+       ```
+       supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
+       ```
+       - Update the following tag according to the sample:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
+       ```
+       4. Restart the servers.
+       5. Download the following certificates and keys, and use them for testing purposes.
+       - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
+       [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
+       layer security testing purposes.
+       - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
+       [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
 
-    ``` tab='Format'
-    
-    {
-    "alg": "<The algorithm used for signing.>",
-    "kid": "<The thumbprint of the certificate.>",
-    "typ": "JWT"
-    }
-    {
-    "iss": "<This is the issuer of the token. For example, client ID of your application>",
-    "sub": "<This is the subject identifier of the issuer. For example, client ID of your application>",
-    "exp": <This is the epoch time of the token expiration date/time>,
-    "iat": <This is the epoch time of the token issuance date/time>,
-    "jti": "<This is an incremental unique value>",
-    "aud": "<This is the audience that the ID token is intended for. For example, https://<IS_HOST>:9446/oauth2/token>"
-    }
-   
-    <signature: The client assertion must be signed using the private key of the application certificate.>
-
-    ```
-    
-    ``` tab='Sample'
-    eyJraWQiOiJXX1RjblFWY0hBeTIwcTh6Q01jZEJ5cm9vdHciLCJhbGciOiJQUzI1NiJ9.eyJzdWIiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiYXVkIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTQ0Ni9vYXV0aDIvdG9rZW4iLCJpc3MiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiZXhwIjoxODI3NjY5MzMyLCJpYXQiOjE4Mjc2NTkzMzIsImp0aSI6IjE0MzIyNDM2MzQzNDM1NDQ1In0.qUq9q_Qa5eiVW5C6QzMvB1sX9Ttwz0Db8c2wmRXyrUWDpeoaolUYT_Diu1o33R4U4MME3nBMCdl0wQ1AVnuzjgV6s3TLcyxlphcoGXYVwOLsQBfbLKTzGiz10UORb3WQc9BwxhZVPDWyFXGlqUNwjPbaUslWoal9KMsbnXlBFKQd8GWjhS-kXHn66kAHwH-7DLZ_Z7D01oW2aFon5sWBZfKD_t9NeQJ9gdPs45ermSM45FixlKXkPPXiIq-_w5Hw1Zw_lEW6fVpWCS6IRz5pBtpHO8s_KESjxuPb1dzrV31AZC7BplWeaRRC5UslObbejw35P5v9CQqJR5Uc7_mX0Q
-    ```
-
-3. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 ``` curl
-curl -X POST \
-https://<IS_HOST>:9446/oauth2/token \
---cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
--d 'grant_type=client_credentials&scope=payments%20openid&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion=<CLIENT_ASSERTION_JWT>&redirect_uri=<REDIRECT_URI>&client_id=<CLIENT_ID>'
-```
+   curl -X POST \
+   https://localhost:9446/oauth2/token \
+   --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+   -d 'grant_type=client_credentials&scope=payments%20openid&client_id=<CLIENT_ID>'
+   ```
 
-3. Upon successful token generation, you can obtain a token as follows:
+2. Upon successful token generation, you can obtain a token as follows:
 ``` json
 {
    "access_token":"eyJ4NXQiOiJOVGRtWmpNNFpEazNOalkwWXpjNU1tWm1PRGd3TVRFM01XWXdOREU1TVdSbFpEZzROemM0WkEiLCJraWQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZ19SUzI1NiIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiJhZG1pbkB3c28yLmNvbUBjYXJib24uc3VwZXIiLCJhdXQiOiJBUFBMSUNBVElPTiIsImF1ZCI6IlBTREdCLU9CLVVua25vd24wMDE1ODAwMDAxSFFRclpBQVgiLCJuYmYiOjE2NDY4OTEyNzIsImF6cCI6IlBTREdCLU9CLVVua25vd24wMDE1ODAwMDAxSFFRclpBQVgiLCJzY29wZSI6InBheW1lbnRzIiwiaXNzIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTQ0Ni9vYXV0aDIvdG9rZW4iLCJjbmYiOnsieDV0I1MyNTYiOiJ5YmVxYUltNTAwSU1QeTE5VmtQZkhSVEpOdDlxdl9RdDVqbUhkdC1iSm1jIn0sImV4cCI6MTY0Njg5NDg3MiwiaWF0IjoxNjQ2ODkxMjcyLCJqdGkiOiI0Zjg0NmQwMS00ZjAxLTQ4YTAtYjliMi1iOTdjNzRmZjUxYTgifQ.CklCtjHYMzc_7u8EacYPQ-O7mhrFs-oR3pIk1fVz93dYwB5Bq959Z--TCT1BIxzWWEhnuD6jiVmdzJQ8LrZu7LczF-lyaP21UEAM5a23ZXmeG_5WZHXONWmKbo4mvcswqwJXbS9dOO1JU8Rx59JMP2zGBjbK3xf0zalWNC4IqQO6xhl8EzcoBahkqBwcygmhf3QyCKXozZpnCqG7HcYwYVFU7F0SKrGpDl2TZ9axWzBjvVOAK9d0G8EQhGjpNy0FY1lS4ZZGbPrUGTuoWBG1WEfqI_CTU7gXi_gGClKjWGXbqEy8FIgh34GCOt5xwx7XJ-nkwzwQzjXtgO1ZNOmdlA",
@@ -541,9 +516,9 @@ given below:
 
 In this section, you will be generating an access token using the authorization code generated in the section [above](#authorizing-a-consent).
 
-1. Generate the client assertion by signing the following JSON payload using supported algorithms. 
-
-    ??? note "Use the sample certificates for signing and transport layer security testing purposes. Click here to see how it is done..."
+1. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
+    
+    ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
         1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
             - The client trust stores for the Identity Server and API Manager are located in the following locations:
                    - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
@@ -570,36 +545,11 @@ In this section, you will be generating an access token using the authorization 
             - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
               [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
 
-    ``` tab="Format"
-      {
-      "alg": "<The algorithm used for signing.>",
-      "kid": "<The thumbprint of the certificate.>",
-      "typ": "JWT"
-      }
-     
-      {
-      "iss": "<This is the issuer of the token. For example, client ID of your application>",
-      "sub": "<This is the subject identifier of the issuer. For example, client ID of your application>",
-      "exp": <This is the epoch time of the token expiration date/time>,
-      "iat": <This is the epoch time of the token issuance date/time>,
-      "jti": "<This is an incremental unique value>",
-      "aud": "<This is the audience that the ID token is intended for. For example, https://<IS_HOST>:9446/oauth2/token>"
-      }
-   
-      <signature: The client assertion must be signed using the private key of the application certificate.>
-    ```
-
-    ``` tab="Sample"
-    eyJraWQiOiJXX1RjblFWY0hBeTIwcTh6Q01jZEJ5cm9vdHciLCJhbGciOiJQUzI1NiJ9.eyJzdWIiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiYXVkIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTQ0Ni9vYXV0aDIvdG9rZW4iLCJpc3MiOiJQU0RHQi1PQi1Vbmtub3duMDAxNTgwMDAwMUhRUXJaQUFYIiwiZXhwIjoxODI3NjY5MzMyLCJpYXQiOjE4Mjc2NTkzMzIsImp0aSI6IjE0MzIyNDM2MzQzNDM1NDQ1In0.qUq9q_Qa5eiVW5C6QzMvB1sX9Ttwz0Db8c2wmRXyrUWDpeoaolUYT_Diu1o33R4U4MME3nBMCdl0wQ1AVnuzjgV6s3TLcyxlphcoGXYVwOLsQBfbLKTzGiz10UORb3WQc9BwxhZVPDWyFXGlqUNwjPbaUslWoal9KMsbnXlBFKQd8GWjhS-kXHn66kAHwH-7DLZ_Z7D01oW2aFon5sWBZfKD_t9NeQJ9gdPs45ermSM45FixlKXkPPXiIq-_w5Hw1Zw_lEW6fVpWCS6IRz5pBtpHO8s_KESjxuPb1dzrV31AZC7BplWeaRRC5UslObbejw35P5v9CQqJR5Uc7_mX0Q
-    ```
-
-2. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
-    
-    ```
+    ``` curl
     curl -X POST \
     https://<IS_HOST>:9446/oauth2/token \
     --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
-    -d 'client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&code=<GENERATED_CODE>&grant_type=authorization_code&redirect_uri=<REDIRECT_URI>&client_assertion=<CLIENT_ASSERTION_JWT>&code_verifier=<CODE_VERIFIER>'
+    -d 'code=<GENERATED_CODE>&grant_type=authorization_code&redirect_uri=<REDIRECT_URI>&code_verifier=<CODE_VERIFIER>&client_id=<CLIENT_ID>'
     ```
 
 3. Upon successful token generation, you can obtain a token as follows:

--- a/en/docs/try-out/payment-initiation-service-flow.md
+++ b/en/docs/try-out/payment-initiation-service-flow.md
@@ -38,7 +38,7 @@ Once you register the application, generate an application access token.
 
 ``` curl
    curl -X POST \
-   https://localhost:9446/oauth2/token \
+   https://<IS_HOST>:9446/oauth2/token \
    --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
    -d 'grant_type=client_credentials&scope=payments%20openid&client_id=<CLIENT_ID>'
    ```
@@ -680,7 +680,7 @@ Header: X-Request-ID: f044aa8c-eee3-4d2b-8c22-49652bdf1531
 **GET /periodic-payments/{payment-product}/{paymentId}**
 
 ``` tab="Request"
-curl -X GET 'https://localhost:8243/xs2a/v1/periodic-payments/sepa-credit-transfers/31169aed-3a46-4404-9035-99de2e776a60' \
+curl -X GET 'https://<APIM_HOST>:8243/xs2a/v1/periodic-payments/sepa-credit-transfers/31169aed-3a46-4404-9035-99de2e776a60' \
 -H 'PSU-IP-Address: 127.0.1.1' \
 -H 'PSU-ID-Type: email' \
 -H 'X-Request-ID: eea1ced4-2ae3-499a-9e10-192d8e2ecb7a' \
@@ -729,7 +729,7 @@ This request is applicable for instant payments, bulk payments, and periodic pay
 Given below is a sample request for a periodic payment:
 
 ``` tab="Request"
-curl -X GET 'https://localhost:8243/xs2a/v1/periodic-payments/sepa-credit-transfers/31169aed-3a46-4404-9035-99de2e776a60/status' \
+curl -X GET 'https://<APIM_HOST>:8243/xs2a/v1/periodic-payments/sepa-credit-transfers/31169aed-3a46-4404-9035-99de2e776a60/status' \
 -H 'PSU-IP-Address: 127.0.1.1' \
 -H 'PSU-ID-Type: email' \
 -H 'X-Request-ID: d029c37a-d464-4304-b175-7c27fd7f5728' \
@@ -786,7 +786,7 @@ To cancel an already submitted payment
 Sample DELETE Request for a bulk payment cancellation without authorization is given below:
 
 ``` tab="Request"
-curl -X DELETE 'https://localhost:8243/xs2a/v1/bulk-payments/sepa-credit-transfers/ecf7844a-6876-47c5-86e3-e41c005bd517' \
+curl -X DELETE 'https://<APIM_HOST>:8243/xs2a/v1/bulk-payments/sepa-credit-transfers/ecf7844a-6876-47c5-86e3-e41c005bd517' \
 -H 'X-Request-ID: 94343777-125d-4d87-80d7-ab62c668514b' \
 -H 'PSU-IP-Address: 127.0.0.1' \
 -H 'TPP-Signature-Certificate: <SIGNATURE_CERTIFICATE>' \
@@ -809,7 +809,7 @@ Header: 'X-Request-ID: 94343777-125d-4d87-80d7-ab62c668514b'
 Sample DELETE Request for a bulk payment cancellation with authorization is given below:
 
 ``` tab="Request"
-curl -X DELETE 'https://localhost:8243/xs2a/v1/bulk-payments/sepa-credit-transfers/ecf7844a-6876-47c5-86e3-e41c005bd517' \
+curl -X DELETE 'https://<APIM_HOST>:8243/xs2a/v1/bulk-payments/sepa-credit-transfers/ecf7844a-6876-47c5-86e3-e41c005bd517' \
 -H 'X-Request-ID: 94343777-125d-4d87-80d7-ab62c668514b' \
 -H 'PSU-IP-Address: 127.0.0.1' \
 -H 'TPP-Signature-Certificate: <SIGNATURE_CERTIFICATE>' \
@@ -857,7 +857,7 @@ If the bank returns `202` with the above payload for the `DELETE` request, the `
 A sample POST cancellation authorisations request for bulk payments type is given below:
 
 ``` tab="Request"
-curl -X POST 'https://localhost:8243/xs2a/v1/bulk-payments/sepa-credit-transfers/697a4c4b-b939-4a18-8bfa-eae30ea90804/cancellation-authorisations' \
+curl -X POST 'https://<APIM_HOST>:8243/xs2a/v1/bulk-payments/sepa-credit-transfers/697a4c4b-b939-4a18-8bfa-eae30ea90804/cancellation-authorisations' \
 -H 'Content-Type: application/json' \
 -H 'PSU-IP-Address: 127.0.1.1' \
 -H 'PSU-ID-Type: email' \
@@ -899,7 +899,7 @@ ASPSP-SCA-Approach: REDIRECT
 If the `POST cancellation-authorisations` request is successful, the TPP should send the authorization request as follows to inform the bank to cancel the payment. Then the bank displays a page similar to the consent page asking the PSU to approve or deny the cancellation authorization. 
 
 ```
-https://localhost:9446/oauth2/authorize/?scope=pis:<payment_id>&response_type=code&redirect_uri=<redirect_uri>&state=55e9d72a-218c-44bb-824e-cf0d61c3fdb1&code_challenge_method=S256&client_id=<client_id>&code_challenge=re6uXq06M40gS82XcmUM6s9SQVTxtY5bLSYCNLuS1XE
+https://<IS_HOST>:9446/oauth2/authorize/?scope=pis:<payment_id>&response_type=code&redirect_uri=<redirect_uri>&state=55e9d72a-218c-44bb-824e-cf0d61c3fdb1&code_challenge_method=S256&client_id=<client_id>&code_challenge=re6uXq06M40gS82XcmUM6s9SQVTxtY5bLSYCNLuS1XE
 ```
 
 Given below is a sample page for cancellation authorization for bulk payment type:

--- a/en/docs/try-out/tpp-onboarding.md
+++ b/en/docs/try-out/tpp-onboarding.md
@@ -109,41 +109,47 @@ The TPP application requires a Client ID (Consumer Key) to access the subscribed
 
 4. Note down the **Consumer Key** for your application.
 
-5. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
+   5. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 
-   ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
-       1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
-       - The client trust stores for the Identity Server and API Manager are located in the following locations:
-       - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
-       - `<IS_HOME>/repository/resources/security/client-truststore.jks`
-       2. Use the following commands to add the certificate to the client trust store:
-       ```shell
-       keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
-       ```
-       3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-       - Add `SHA1withRSA` as a supported signature algorithm:
-       ```
-       supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
-       ```
-       - Update the following tag according to the sample:
-       ```
-       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OpenBanking Pre-Production Issuing CA, OU=OpenBanking, O=WSO2 (UK) LIMITED, L=COL, ST=WP, C=LK"
-       ```
-       4. Restart the servers.
-       5. Download the following certificates and keys, and use them for testing purposes.
-       - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
-       [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
-       layer security testing purposes.
-       - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
-       [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.    
+      ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
+          1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
+          - The client trust stores for the Identity Server and API Manager are located in the following locations:
+          - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
+          - `<IS_HOME>/repository/resources/security/client-truststore.jks`
+          2. Use the following commands to add the certificate to the client trust store:
+          ```shell
+          keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
+          ```
+          3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
+             - Add the relevant signature algorithm supported by the certificate to the following configuration.
+             - Sample certificate supports `SHA1withRSA` signature algorithm:
+          ```
+          supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
+          ```
+          - Configure the issuer of the certificate as below if the certificate needs to be skipped form revocation validation:
+          ```
+          [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+          issuer_dn = "EMAILADDRESS=<EMAIL_ADDRESS>, CN=<COMMON_NAME>, OU=<ORGANIZATIONAL_UNIT>, O=<ORGANIZATION>, L=<LOCALITY>, ST=<STATE/PROVINCE>, C=<COUNTRY>"
+          ```
+          - Configure as below if the test certificates are used:
+          ```
+          [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+          issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OB, OU=OB, O=WSO2, L=COL, ST=WP, C=LK"
+          ```
+          4. Restart the servers.
+          5. Download the following certificates and keys, and use them for testing purposes.
+          - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
+          [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
+          layer security testing purposes.
+          - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
+          [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.    
 
-   ``` curl
-   curl -X POST \
-   https://<IS_HOST>:9446/oauth2/token \
-   --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
-   -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
-   ```
+      ``` curl
+      curl -X POST \
+      https://<IS_HOST>:9446/oauth2/token \
+      --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+      -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
+      ```
 
 7. Upon successful token generation, you can obtain an access token as follows:
 

--- a/en/docs/try-out/tpp-onboarding.md
+++ b/en/docs/try-out/tpp-onboarding.md
@@ -148,7 +148,7 @@ The TPP application requires a Client ID (Consumer Key) to access the subscribed
       curl -X POST \
       https://<IS_HOST>:9446/oauth2/token \
       --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
-      -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
+      -d 'grant_type=client_credentials&scope=accounts&client_id=<CLIENT_ID>'
       ```
 
 7. Upon successful token generation, you can obtain an access token as follows:

--- a/en/docs/try-out/tpp-onboarding.md
+++ b/en/docs/try-out/tpp-onboarding.md
@@ -109,73 +109,41 @@ The TPP application requires a Client ID (Consumer Key) to access the subscribed
 
 4. Note down the **Consumer Key** for your application.
 
-5. Generate the client assertion by signing the following JSON payload using supported algorithms.
+5. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
 
-    ??? note "Use the sample certificates for signing and transports layer security testing purposes. Click here to see how it is done..."
-        1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
-            - The client trust stores for the Identity Server and API Manager are located in the following locations:
-               - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
-               - `<IS_HOME>/repository/resources/security/client-truststore.jks`
-        2. Use the following commands to add the certificate to the client trust store:
-               ```shell
-               keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
-               ```
-        3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
-            - Add `SHA1withRSA` as a supported signature algorithm:
-               ```
-               supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
-               ```
-            - Update the following tag according to the sample:
-               ```
-               [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
-               issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OpenBanking Pre-Production Issuing CA, OU=OpenBanking, O=WSO2 (UK) LIMITED, L=COL, ST=WP, C=LK"
-               ```
-        4. Restart the servers.
-        5. Download the following certificates and keys, and use them for testing purposes.
-            - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
-              [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
-              layer security testing purposes.
-            - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
-              [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.
+   ??? note "Use the sample certificates for testing purposes. Click here to see how it is done..."
+       1. Download the [cert.pem](../../assets/attachments/cert.pem) and upload it to the client trust stores as follows:
+       - The client trust stores for the Identity Server and API Manager are located in the following locations:
+       - `<APIM_HOME>/repository/resources/security/client-truststore.jks`
+       - `<IS_HOME>/repository/resources/security/client-truststore.jks`
+       2. Use the following commands to add the certificate to the client trust store:
+       ```shell
+       keytool -import -alias cert -file <PATH_TO_CERT.PEM> -keystore client-truststore.jks -storepass wso2carbon
+       ```
+       3. Open the `<APIM_HOME>/repository/conf/deployment.toml` file and update the following configurations:
+       - Add `SHA1withRSA` as a supported signature algorithm:
+       ```
+       supported_signature_algorithms = ["SHA256withRSA", "SHA512withRSA", "SHA1withRSA"]
+       ```
+       - Update the following tag according to the sample:
+       ```
+       [[open_banking.gateway.certificate_management.certificate.revocation.excluded]]
+       issuer_dn = "EMAILADDRESS=malshani@wso2.com, CN=OpenBanking Pre-Production Issuing CA, OU=OpenBanking, O=WSO2 (UK) LIMITED, L=COL, ST=WP, C=LK"
+       ```
+       4. Restart the servers.
+       5. Download the following certificates and keys, and use them for testing purposes.
+       - Use the [transport private key](../../assets/attachments/transport-certs/obtransport.key) and
+       [transport public certificate](../../assets/attachments/transport-certs/obtransport.pem) for Transport
+       layer security testing purposes.
+       - Use the [signing certificate](../../assets/attachments/signing-certs/obsigning.pem) and
+       [signing private keys](../../assets/attachments/signing-certs/obsigning.key) for signing purposes.    
 
-    ``` tab='Format'
-    
-    {
-    "alg": "<The algorithm used for signing.>",
-    "kid": "<The thumbprint of the certificate.>",
-    "typ": "JWT"
-    }
-     
-    {
-    "iss": "<This is the issuer of the token. For example, client ID of your application>",
-    "sub": "<This is the subject identifier of the issuer. For example, client ID of your application>",
-    "exp": <This is the epoch time of the token expiration date/time>,
-    "iat": <This is the epoch time of the token issuance date/time>,
-    "jti": "<This is an incremental unique value>",
-    "aud": "<This is the audience that the ID token is intended for. For example, https://<IS_HOST>:9446/oauth2/token>"
-    }
-     
-    <signature: The client assertion must be signed using the private key of the application certificate.>
-    ```
-    
-    ``` tab='Sample'
-    eyJraWQiOiIyTUk5WFNLaTZkZHhDYldnMnJoRE50VWx4SmMiLCJhbGciOiJQUzI1NiJ9.eyJzdWIiOiJZRGNHNGY0OUcxM2tXZlZzbnFkaHo4Z2JhMndhIiwiYXVkIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTQ0Ni9vYXV0aDIvdG9rZW4iLCJpc3MiOiJZRGNHNGY0OUcxM2tXZlZzbnFkaHo4Z2JhMndhIiwiZXhwIjoxNjI4Nzc0ODU1LCJpYXQiOjE2Mjg3NDQ4NTUsImp0aSI6IjE2Mjg3NDQ4NTUxOTQifQ.PkKRSDtkCyXabzLgGwAoy5C3jSORVU8X8sGDVrKpetPnjbCNx2wPlH-PzWUU1n05gdC7lDmoU21nsKLF_nE3iC-9hKEy4YsvJ7PFjNBPMOMUYDhRh9PCkPnec6f042zonb_ZifBq8r1aScUDoZ1L0hq7yjfZubwReFCWbESQ8PauuBuHRl7__kWvglthfgruQ7TTiIWiM60LWYct5TQWSF1IDcYGy03l-9OV5l260JBHPT4heLXzUQTarsh0PoWpv09xYLu8uGCexEt-HtRH8qwJGiFi5PiCA09_KyWVqbrcdjBloCmD5Kiqa1X0AnEbf9kKs0fqvcl7NN5-yVQUjg
-    ```
-    
-    ??? tip "The value of the `aud` claim should contain the same value as the `Identity Provider Entity ID`. Click here to see the Identity Provider Entity ID..."
-        a. Sign in to the Management Console of the Identity Server at `<https://<localhost>t:9446/carbon>`.
-    
-        b. In the **Main** menu, go to **Home > Identity > Identity Providers > Resident**.
-    
-        c. View the value in **Resident Identity Provider > Inbound Authentication Configuration > OAuth2/OpenID Connect Configuration > Identity Provider Entity ID**. By default this value is set to `https://<APIM_HOST>:8243/token` .
-
-6. Run the following cURL command in a command prompt to generate the access token. Update the placeholders with relevant values.
-    ``` curl
-    curl -X POST \
-    https://<IS_HOST>:9446/oauth2/token \
-    --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
-    -d 'grant_type=client_credentials&scope=accounts%20openid&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion=<CLIENT_ASSERTION_JWT>&redirect_uri=<REDIRECT_URI>&client_id=<CLIENT_ID>'
-    ```
+   ``` curl
+   curl -X POST \
+   https://localhost:9446/oauth2/token \
+   --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+   -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
+   ```
 
 7. Upon successful token generation, you can obtain an access token as follows:
 

--- a/en/docs/try-out/tpp-onboarding.md
+++ b/en/docs/try-out/tpp-onboarding.md
@@ -140,7 +140,7 @@ The TPP application requires a Client ID (Consumer Key) to access the subscribed
 
    ``` curl
    curl -X POST \
-   https://localhost:9446/oauth2/token \
+   https://<IS_HOST>:9446/oauth2/token \
    --cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
    -d 'grant_type=client_credentials&scope=accounts%20openid&client_id=<CLIENT_ID>'
    ```


### PR DESCRIPTION
## Purpose

- Removes the client assertion generation-related notes.
- Restructure the sample certificate blocks relevantly.
- Update token call cURL commands to MTLS token requests.